### PR TITLE
Migrate caterpillars.xml popSize to spec, add exec:exec for testing

### DIFF
--- a/examples/caterpillars.xml
+++ b/examples/caterpillars.xml
@@ -115,8 +115,8 @@ name="alignment">
             <stateNode id="ORCRates.c:caterpillars" spec="beast.base.spec.inference.parameter.RealVectorParam" dimension="138" domain="PositiveReal">1.0</stateNode>
         </state>
         <init id="RandomTree.t:caterpillars" spec="RandomTree" estimate="false" initial="@Tree.t:caterpillars" taxa="@caterpillars">
-            <populationModel id="ConstantPopulation0.t:caterpillars" spec="ConstantPopulation">
-                <parameter id="randomPopSize.t:caterpillars" spec="parameter.RealParameter" name="popSize">1.0</parameter>
+            <populationModel id="ConstantPopulation0.t:caterpillars" spec="beast.base.spec.evolution.tree.coalescent.ConstantPopulation">
+                <popSize id="randomPopSize.t:caterpillars" spec="beast.base.spec.inference.parameter.RealScalarParam" domain="PositiveReal" value="1.0"/>
             </populationModel>
         </init>
         <distribution id="posterior" spec="CompoundDistribution">

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>25</maven.compiler.release>
-        <beast.version>2.8.0-beta1</beast.version>
+        <beast.version>2.8.0-beta5</beast.version>
         <beast.pkg.name>ORC</beast.pkg.name>
         <beast.pkg.version>1.3.0</beast.pkg.version>
+        <beast.module>beast.base</beast.module>
+        <beast.main>beast.base.minimal.BeastMain</beast.main>
+        <beast.args/>
         <javafx.version>25.0.2</javafx.version>
         <commons-statistics.version>1.2</commons-statistics.version>
     </properties>
@@ -159,6 +162,20 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Run BEAST or BEAUti with ORC on module path:
+                 mvn exec:exec -Dbeast.args="examples/some.xml"
+                 mvn exec:exec -Dbeast.module=beast.fx -Dbeast.main=beastfx.app.beauti.Beauti -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <executable>java</executable>
+                    <workingDirectory>${project.basedir}</workingDirectory>
+                    <commandlineArgs>--module-path %classpath -DBEAST_PACKAGE_PATH=${project.build.outputDirectory} -m ${beast.module}/${beast.main} ${beast.args}</commandlineArgs>
+                </configuration>
             </plugin>
 
             <!-- Assemble BEAST package ZIP -->


### PR DESCRIPTION
## Summary

- **`examples/caterpillars.xml`** — replaced the last legacy `parameter.RealParameter` declaration (the `popSize` of the init `ConstantPopulation`) with a spec `RealScalarParam` (`PositiveReal`). The enclosing `populationModel` also had to move from the legacy `ConstantPopulation` to `beast.base.spec.evolution.tree.coalescent.ConstantPopulation`, since the legacy classes are deprecated and migrated examples should not reference them.
- **`pom.xml`** — bumped `beast.version` `2.8.0-beta1` → `2.8.0-beta5` (the version other beast3-migrated packages target), and added the standard `exec-maven-plugin` block used by [bModelTest](https://github.com/BEAST2-Dev/bModelTest) / [flc](https://github.com/4ment/flc):

  ```
  mvn exec:exec -Dbeast.args="examples/caterpillars.xml"
  mvn exec:exec -Dbeast.module=beast.fx -Dbeast.main=beastfx.app.beauti.Beauti
  ```

After these changes, the [beast3 migration scanner](https://github.com/CompEvol/beast3-migration) reports ORC's XML and FxTemplates columns as clean. The only remaining flag is on the Java side: two over-concrete `Input` declarations on `orc.inference.TipRateLogger` — a separate fix.

## Test plan

- [x] `mvn -DskipTests package` builds against `beast 2.8.0-beta5`.
- [x] `mvn exec:exec -Dbeast.args="-overwrite -seed 1 examples/caterpillars.xml"` (temporarily set `chainLength=1000`) ran the full MCMC to completion; start logL ≈ -51594, end logL ≈ -40581.
- [ ] Run with the original `chainLength=10000000` if you want to confirm long-run stability before merging.